### PR TITLE
Replaced dense matrices with scipy dok_matrix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,24 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+
+# C extensions
+*.so
+
+# Distribution / packaging
+bin/
+build/
+develop-eggs/
+dist/
+eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# Sphinx documentation
+docs/_build/

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,11 @@ __pycache__/
 # C extensions
 *.so
 
+# Result file extensions
+*.dat
+*.vtu
+
+
 # Distribution / packaging
 bin/
 build/

--- a/modules/arclenmodule.py
+++ b/modules/arclenmodule.py
@@ -3,6 +3,7 @@ import numpy as np
 import scipy.sparse as sparse
 import scipy.sparse.linalg as linalg
 
+from scipy.sparse import dok_matrix
 from numpy.linalg import norm as norm
 
 from names import GlobNames as gn
@@ -45,7 +46,7 @@ class ArclenModule(ControlModule):
             globdat[gn.LAMBDA] = 0.
             self._duOld = np.zeros(dc)
 
-        K = np.zeros((dc, dc))
+        K = dok_matrix((dc,dc),dtype="float64")
         fint = np.zeros(dc)
         fhat = self._fhat
         c = Constrainer()
@@ -97,7 +98,7 @@ class ArclenModule(ControlModule):
         # Initialize iteration loop
         while rel > self._tolerance and iteration < self._itermax:
             iteration += 1
-            params[pn.MATRIX0] = np.zeros((dc, dc))
+            params[pn.MATRIX0] = dok_matrix((dc,dc),dtype="float64")
             params[pn.INTFORCE] = np.zeros(dc)
             model.take_action(act.GETMATRIX0, params, globdat)
             fext = fext0 + Dlam * fhat
@@ -147,9 +148,8 @@ class ArclenModule(ControlModule):
 
 
 def solveSys(K, f, c):
-    Kc, fc = c.constrain(K, f)
-    smat = sparse.csr_matrix(Kc)
-    u = linalg.spsolve(smat, fc)
+    c.constrain(K, f)
+    u = linalg.spsolve(K.tocsr(), f)
     return u
 
 

--- a/utils/constrainer.py
+++ b/utils/constrainer.py
@@ -1,4 +1,5 @@
 import numpy as np
+import copy
 
 
 class Constrainer:
@@ -16,20 +17,16 @@ class Constrainer:
             self._vals.append(val - self._state0[dof])
 
     def constrain(self, k, f):
-        kc = np.copy(k)
-        fc = np.copy(f)
 
         for dof, val in zip(self._dofs, self._vals):
-            for i in range(kc.shape[0]):
+            for i in range(k.get_shape()[0]):
                 if i == dof:
-                    fc[i] = val
+                    f[i] = val
                 else:
-                    fc[i] -= kc[i, dof] * val
+                    f[i] -= k[i, dof] * val
 
-            kc[:, dof] = kc[dof, :] = 0.0
-            kc[dof, dof] = 1.0
-
-        return kc, fc
+            k[:, dof] = k[dof, :] = 0.0
+            k[dof, dof] = 1.0
 
     def constraindiag(self, k, f):
         kc = np.copy(k)


### PR DESCRIPTION
The inherently sparse stiffness matrix K is initialized as a dense matrix, which wastes memory. It is now switched to scipy dok_matrix.